### PR TITLE
Fix subtract() function not working with parameter type other than Big

### DIFF
--- a/Godot 4.1.x/Big.gd
+++ b/Godot 4.1.x/Big.gd
@@ -246,6 +246,8 @@ static func add(x, y) -> Big:
 
 ## Subtracts two numbers and returns the Big number result
 static func subtract(x, y) -> Big:
+	x = Big._typeCheck(x)
+	y = Big._typeCheck(y)
 	var negated_y := Big.new(-y.mantissa, y.exponent)
 	return add(negated_y, x)
 


### PR DESCRIPTION
Added type check of the parameter of the subtract() function. (same as in add() function)
Now subtract() works with a float as a parameter.

I had the problem that the minusEquals() function did not work with a float as a parameter. The problem was that in the subtract() function, the parameters were not converted into a Big before accessing the attribute "exponent" of the parameter.