### PR TITLE
fix for number in thousands to go to the proper decimal.

### DIFF
--- a/Godot 4.1.x/Big.gd
+++ b/Godot 4.1.x/Big.gd
@@ -757,7 +757,7 @@ func toPrefix(no_decimals_on_small_values = false, use_thousand_symbol=true, for
 				for i in range(3):
 					if split[1].length() < 3:
 						split[1] += "0"
-				return split[0] + options.decimal_separator + split[1].substr(0,min(3, options.dynamic_numbers - split[0].length() if options.dynamic_decimals else 3))
+				return split[0] + options.decimal_separator + split[1].substr(0,min(options.thousand_decimals, options.dynamic_numbers - split[0].length() if options.dynamic_decimals else 3))
 			else:
 				for i in range(3):
 					if split[1].length() < 3:


### PR DESCRIPTION
on line 760 the number 3 should be options.thousand_decimals in order to properly change the options to set the decimal place. otherwise it will always be the 3 decimals that is currently on line 760

example the way it is numbers in the thousands will always show 152.123k 3 decimal places.
the fix changes the amount of decimal places according to the option. so if you have 1 then the example above will be 152.1k