### PR TITLE
Mantissa Floating Point Imprecision in Normalize

### DIFF
--- a/Godot 4.1.x/Big.gd
+++ b/Godot 4.1.x/Big.gd
@@ -194,6 +194,7 @@ static func normalize(big: Big) -> void:
         is_negative = true
         big.mantissa *= -1
         
+    big.mantissa = snapped(big.mantissa, MANTISSA_PRECISION)
     if big.mantissa < 1.0 or big.mantissa >= 10.0:
         var diff: int = floor(log10(big.mantissa))
         if diff > -10 and diff < 248:


### PR DESCRIPTION
Fixed occasional issue when normalizing a mantissa that should be 10.0, but is actually 9.9999... due to floating point imprecision