### PR TITLE
Adds default values for mantissa and exponent

### DIFF
--- a/Godot 4.1.x/Big.gd
+++ b/Godot 4.1.x/Big.gd
@@ -159,7 +159,7 @@ const INT_MIN: int = -9223372036854775808
 ## int (signed 64-bit) maximum value
 const INT_MAX: int = 9223372036854775807
 
-func _init(m: Variant = options["default_value"], e: int = options["default_exponent"]) -> void:
+func _init(m: Variant = options["default_mantissa"], e: int = options["default_exponent"]) -> void:
     if m is Big:
         mantissa = m.mantissa
         exponent = m.exponent

--- a/Godot 4.1.x/Big.gd
+++ b/Godot 4.1.x/Big.gd
@@ -132,6 +132,8 @@ const latin_special: Array[String] = [
 
 ## Various options to control the string presentation of Big Numbers
 static var options = {
+    "default_mantissa": 1.0,
+    "default_exponent": 0,
     "dynamic_decimals": false, 
     "dynamic_numbers": 4, 
     "small_decimals": 2, 
@@ -157,7 +159,7 @@ const INT_MIN: int = -9223372036854775808
 ## int (signed 64-bit) maximum value
 const INT_MAX: int = 9223372036854775807
 
-func _init(m: Variant = 1.0, e: int = 0) -> void:
+func _init(m: Variant = options["default_value"], e: int = options["default_exponent"]) -> void:
     if m is Big:
         mantissa = m.mantissa
         exponent = m.exponent
@@ -609,6 +611,18 @@ func pow10(value: int) -> void:
     mantissa = 10 ** (value % 1)
     exponent = int(value)
 
+## Sets the Default (m)antissa and (e)xponent options, these are the default mantissa and exponent used when creating a new Big number
+static func setDefaultValue(m: float, e: int) -> void:
+    setDefaultMantissa(m)
+    setDefaultExponent(e)
+
+## Sets the Default mantissa option, this is the default mantissa used when creating a new Big number
+static func setDefaultMantissa(value: float) -> void:
+    options["default_mantissa"] = value
+
+## Sets the Default Exponent option, this is the default exponent used when creating a new Big number
+static func setDefaultExponent(value: int) -> void:
+    options["default_exponent"] = value
 
 ## Sets the Thousand name option
 static func setThousandName(name: String) -> void:

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ const Big = preload("res://path/to/Big.gd")
 Multiple constructors can be used to instantiate a `Big` number:
 
 ```GDScript
+var big_default = Big.new() # Creates a big with the default values as set in the options, see static functions on how to set the options
 var big_int = Big.new(100)  # From an integer
 var big_exp = Big.new(2, 6) # Using a mantissa and exponent;
                             # here means 2,000,000
@@ -118,6 +119,16 @@ The following static functions are available:
 var smallest = Big.minValue(big_value, value)
 var largest = Big.maxValue(big_value, value)
 var positive = Big.absolute(big_value)
+```
+
+```GDScript
+# The default mantissa is 1.0 if not changed
+# The default exponent is 0 if not changed
+
+Big.setDefaultValue(0.0, 0) # Sets the default mantissa and exponent for creation for new Bigs
+Big.setDefaultMantissa(0.0) # Sets the default mantissa for creation of new  Bigs
+Big.setDefaultExponent(0)   # Sets the default exponent for creation of new Bigs
+
 ```
 
 ## Formatting as a string


### PR DESCRIPTION
This adds two options that determine the value of a new big when created as Big.new().

Includes updates to documentation.

The impact of the change is minimal and does affect its behavior as long as the options are not changed.